### PR TITLE
Fix: Quick-Sell and Quick-Find on localshop

### DIFF
--- a/src/main/java/me/sat7/dynamicshop/commands/Shop.java
+++ b/src/main/java/me/sat7/dynamicshop/commands/Shop.java
@@ -85,40 +85,24 @@ public final class Shop
                     return;
                 }
             }
-            if (shopConf.contains("flag.localshop") && !shopConf.contains("flag.deliverycharge") && shopConf.contains("world") && shopConf.contains("pos1") && shopConf.contains("pos2"))
-            {
-                boolean outside = !player.getWorld().getName().equals(shopConf.getString("world"));
 
+            boolean outside = !ShopUtil.CheckShopLocation(shopName, player);
+
+            if (outside && !shopConf.contains("flag.deliverycharge") && !player.hasPermission(Constants.P_ADMIN_REMOTE_ACCESS))
+            {
                 String[] shopPos1 = shopConf.getString("pos1").split("_");
-                String[] shopPos2 = shopConf.getString("pos2").split("_");
                 int x1 = Integer.parseInt(shopPos1[0]);
                 int y1 = Integer.parseInt(shopPos1[1]);
                 int z1 = Integer.parseInt(shopPos1[2]);
-                int x2 = Integer.parseInt(shopPos2[0]);
-                int y2 = Integer.parseInt(shopPos2[1]);
-                int z2 = Integer.parseInt(shopPos2[2]);
 
-                if (!((x1 <= player.getLocation().getBlockX() && player.getLocation().getBlockX() <= x2) ||
-                        (x2 <= player.getLocation().getBlockX() && player.getLocation().getBlockX() <= x1)))
-                    outside = true;
-                if (!((y1 <= player.getLocation().getBlockY() && player.getLocation().getBlockY() <= y2) ||
-                        (y2 <= player.getLocation().getBlockY() && player.getLocation().getBlockY() <= y1)))
-                    outside = true;
-                if (!((z1 <= player.getLocation().getBlockZ() && player.getLocation().getBlockZ() <= z2) ||
-                        (z2 <= player.getLocation().getBlockZ() && player.getLocation().getBlockZ() <= z1)))
-                    outside = true;
+                player.sendMessage(DynamicShop.dsPrefix(player) + t(player, "ERR.LOCAL_SHOP_REMOTE_ACCESS"));
 
-                if (outside && !player.hasPermission(Constants.P_ADMIN_REMOTE_ACCESS))
-                {
-                    player.sendMessage(DynamicShop.dsPrefix(player) + t(player, "ERR.LOCAL_SHOP_REMOTE_ACCESS"));
-
-                    String posString = t(player, "SHOP.SHOP_LOCATION");
-                    posString = posString.replace("{x}", n(x1));
-                    posString = posString.replace("{y}", n(y1));
-                    posString = posString.replace("{z}", n(z1));
-                    player.sendMessage(DynamicShop.dsPrefix(player) + posString);
-                    return;
-                }
+                String posString = t(player, "SHOP.SHOP_LOCATION");
+                posString = posString.replace("{x}", n(x1));
+                posString = posString.replace("{y}", n(y1));
+                posString = posString.replace("{z}", n(z1));
+                player.sendMessage(DynamicShop.dsPrefix(player) + posString);
+                return;
             }
             if (shopConf.contains("shophours") && !player.hasPermission(P_ADMIN_SHOP_EDIT))
             {

--- a/src/main/java/me/sat7/dynamicshop/guis/ItemTrade.java
+++ b/src/main/java/me/sat7/dynamicshop/guis/ItemTrade.java
@@ -59,7 +59,7 @@ public final class ItemTrade extends InGameUI
         this.player = player;
         this.shopName = shopName;
         this.tradeIdx = tradeIdx;
-        this.deliveryCharge = CalcShipping(player, shopName);
+        this.deliveryCharge = ShopUtil.CalcShipping(shopName, player);
         this.shopData = ShopUtil.shopConfigFiles.get(shopName).get();
         this.sellBuyOnly = shopData.getString(this.tradeIdx + ".tradeType", "");
         this.material = shopData.getString(tradeIdx + ".mat");
@@ -159,7 +159,7 @@ public final class ItemTrade extends InGameUI
                 ConfigurationSection optionS = data.get().getConfigurationSection("Options");
                 if (optionS.contains("world") && optionS.contains("pos1") && optionS.contains("pos2") && optionS.contains("flag.deliverycharge"))
                 {
-                    deliveryCharge = CalcShipping(player, shopName);
+                    deliveryCharge = ShopUtil.CalcShipping(shopName, player);
                     if (deliveryCharge == -1)
                     {
                         player.sendMessage(DynamicShop.dsPrefix(player) + t(player, "MESSAGE.DELIVERY_CHARGE_NA")); // 다른 월드로 배달 불가능
@@ -173,48 +173,6 @@ public final class ItemTrade extends InGameUI
                     Buy(optionS, tempIS, deliveryCharge, infiniteStock);
             }
         }
-    }
-
-    public static int CalcShipping(Player player, String shopName)
-    {
-        int deliverycharge = 0;
-
-        CustomConfig data = ShopUtil.shopConfigFiles.get(shopName);
-        ConfigurationSection optionS = data.get().getConfigurationSection("Options");
-        if (optionS.contains("world") && optionS.contains("pos1") && optionS.contains("pos2") && optionS.contains("flag.deliverycharge"))
-        {
-            boolean sameworld = true;
-            boolean outside = false;
-            if (!player.getWorld().getName().equals(optionS.getString("world"))) sameworld = false;
-
-            String[] shopPos1 = optionS.getString("pos1").split("_");
-            String[] shopPos2 = optionS.getString("pos2").split("_");
-            int x1 = Integer.parseInt(shopPos1[0]);
-            int y1 = Integer.parseInt(shopPos1[1]);
-            int z1 = Integer.parseInt(shopPos1[2]);
-            int x2 = Integer.parseInt(shopPos2[0]);
-            int y2 = Integer.parseInt(shopPos2[1]);
-            int z2 = Integer.parseInt(shopPos2[2]);
-
-            if (!((x1 <= player.getLocation().getBlockX() && player.getLocation().getBlockX() <= x2) ||
-                    (x2 <= player.getLocation().getBlockX() && player.getLocation().getBlockX() <= x1))) outside = true;
-            if (!((y1 <= player.getLocation().getBlockY() && player.getLocation().getBlockY() <= y2) ||
-                    (y2 <= player.getLocation().getBlockY() && player.getLocation().getBlockY() <= y1))) outside = true;
-            if (!((z1 <= player.getLocation().getBlockZ() && player.getLocation().getBlockZ() <= z2) ||
-                    (z2 <= player.getLocation().getBlockZ() && player.getLocation().getBlockZ() <= z1))) outside = true;
-
-            if (!sameworld)
-            {
-                deliverycharge = -1;
-            } else if (outside)
-            {
-                Location lo = new Location(player.getWorld(), x1, y1, z1);
-                int dist = (int) (player.getLocation().distance(lo) * 0.1 * DynamicShop.plugin.getConfig().getDouble("Shop.DeliveryChargeScale"));
-                deliverycharge = Clamp(dist, DynamicShop.plugin.getConfig().getInt("Shop.DeliveryChargeMin"), DynamicShop.plugin.getConfig().getInt("Shop.DeliveryChargeMax"));
-            }
-        }
-
-        return deliverycharge;
     }
 
     private void CreateBalanceButton()

--- a/src/main/java/me/sat7/dynamicshop/transactions/Sell.java
+++ b/src/main/java/me/sat7/dynamicshop/transactions/Sell.java
@@ -36,7 +36,9 @@ public final class Sell
         double priceBuyOld = Calc.getCurrentPrice(shopName, String.valueOf(tradeIdx), true);
         int stockOld = data.get().getInt(tradeIdx + ".stock");
         int maxStock = data.get().getInt(tradeIdx + ".maxStock", -1);
-        double priceSum;
+
+        double deliveryCharge = ShopUtil.CalcShipping(shopName, player);
+        double priceSum = -deliveryCharge;
 
         // 실제 판매 가능량 확인
         int tradeAmount;
@@ -109,7 +111,7 @@ public final class Sell
             return 0;
         }
 
-        priceSum = Calc.calcTotalCost(shopName, String.valueOf(tradeIdx), -tradeAmount);
+        priceSum += Calc.calcTotalCost(shopName, String.valueOf(tradeIdx), -tradeAmount);
 
         // 재고 증가
         if (stockOld > 0)


### PR DESCRIPTION
As soon as the "localshop" flag was set, the Quick-Sell and Quick-Find functions could no longer be used. - No matter if you were at the right coordinates or not. This pull request corrects this behavior.

You can now use QSell and QFind if you are in the store. Additionally you can use them if you are outside and the store offers delivery.