### PR TITLE
Code improvements and added support for items with long names.

### DIFF
--- a/src/main/java/me/sat7/dynamicshop/commands/CMDManager.java
+++ b/src/main/java/me/sat7/dynamicshop/commands/CMDManager.java
@@ -37,6 +37,8 @@ public class CMDManager
     public static ShopHours shopHours;
     public static StockStabilizing stockStabilizing;
 
+    public static ItemInfo itemInfo;
+
     public static void Init()
     {
         CMDHashMap.clear();
@@ -52,6 +54,8 @@ public class CMDManager
         reload = new Reload();
         setDefaultShop = new SetDefaultShop();
         setTax = new SetTax();
+        itemInfo = new ItemInfo();
+
 
         CMDHashMap.put("cmdhelp", commandHelp);
         CMDHashMap.put("createshop", createShop);
@@ -63,6 +67,7 @@ public class CMDManager
         CMDHashMap.put("reload", reload);
         CMDHashMap.put("setdefaultshop", setDefaultShop);
         CMDHashMap.put("settax", setTax);
+        CMDHashMap.put("iteminfo", itemInfo);
 
         // ds shop
         account = new Account();

--- a/src/main/java/me/sat7/dynamicshop/commands/ItemInfo.java
+++ b/src/main/java/me/sat7/dynamicshop/commands/ItemInfo.java
@@ -1,0 +1,52 @@
+package me.sat7.dynamicshop.commands;
+
+import me.sat7.dynamicshop.DynamicShop;
+import me.sat7.dynamicshop.utilities.StringUtil;
+import org.bukkit.Material;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import static me.sat7.dynamicshop.constants.Constants.P_ADMIN_ITEM_INFO;
+import static me.sat7.dynamicshop.utilities.LangUtil.t;
+
+public class ItemInfo extends DSCMD {
+
+    public ItemInfo() {
+        inGameUseOnly = true;
+        permission = P_ADMIN_ITEM_INFO;
+    }
+
+    @Override
+    public void SendHelpMessage(Player player)
+    {
+        player.sendMessage(DynamicShop.dsPrefix(player) + t(player, "HELP.TITLE").replace("{command}", "iteminfo"));
+        player.sendMessage(" - " + t(player, "HELP.USAGE") + ": /ds iteminfo");
+        player.sendMessage(" - " + t(player, "HELP.ITEMINFO_USAGE"));
+        player.sendMessage("");
+    }
+
+    @Override
+    public void RunCMD(String[] args, CommandSender sender) {
+        if(!CheckValid(args, sender))
+            return;
+        Player p = (Player) sender;
+        Material material = p.getInventory().getItemInMainHand().getType();
+
+        if (material == Material.AIR) {
+            p.sendMessage(DynamicShop.dsPrefix(p) + t(p, "ERR.ITEMINFO_HAND_EMPTY"));
+            return;
+        } else {
+            String result = StringUtil.getShortenedNameSign(material.name());
+            p.sendMessage(DynamicShop.dsPrefix(p) + t(p, "HELP.TITLE").replace("{command}", "iteminfo"));
+            p.sendMessage("");
+            p.sendMessage(t(p, "HELP.ITEMINFO_REALNAME").replace("{item_realname}", material.name().toUpperCase()));
+            p.sendMessage(t(p, "HELP.ITEMINFO_SIGN_NAME").replace("{item_signname}", result));
+            p.sendMessage("");
+        }
+
+
+
+
+        super.RunCMD(args, sender);
+    }
+}

--- a/src/main/java/me/sat7/dynamicshop/constants/Constants.java
+++ b/src/main/java/me/sat7/dynamicshop/constants/Constants.java
@@ -25,6 +25,8 @@ public final class Constants
     public static final String P_USE = "dshop.use"; // 이 권한은 기본적으로 지급됨
     public static final String P_USE_QSELL = "dshop.use.qsell"; // 이 권한은 기본적으로 지급됨
 
+    public static final String P_ADMIN_ITEM_INFO = "dshop.admin.iteminfo";
+
     private Constants()
     {
 

--- a/src/main/java/me/sat7/dynamicshop/events/OnSignClick.java
+++ b/src/main/java/me/sat7/dynamicshop/events/OnSignClick.java
@@ -3,8 +3,10 @@ package me.sat7.dynamicshop.events;
 import me.sat7.dynamicshop.DynaShopAPI;
 import me.sat7.dynamicshop.DynamicShop;
 import me.sat7.dynamicshop.constants.Constants;
+import me.sat7.dynamicshop.utilities.ItemsUtil;
 import me.sat7.dynamicshop.utilities.ShopUtil;
 
+import me.sat7.dynamicshop.utilities.StringUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -25,40 +27,36 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static me.sat7.dynamicshop.constants.Constants.*;
 import static me.sat7.dynamicshop.utilities.LangUtil.t;
+import static org.bukkit.Material.*;
 
 public class OnSignClick implements Listener
 {
     // 생성
     @EventHandler
-    public void onSignChange(SignChangeEvent e)
-    {
+    public void onSignChange(SignChangeEvent e) {
         if (!e.getPlayer().hasPermission(P_ADMIN_CREATE_SIGN)) return;
 
         //noinspection ConstantConditions
         if (e.getLine(0).equalsIgnoreCase("[dshop]")
-            || e.getLine(0).equalsIgnoreCase("[ds]")
-            || e.getLine(0).equalsIgnoreCase("[dynamicshop]"))
-        {
+                || e.getLine(0).equalsIgnoreCase("[ds]")
+                || e.getLine(0).equalsIgnoreCase("[dynamicshop]")) {
             String signId = CreateID(e.getBlock());
 
-            if (e.getLine(1).length() == 0)
-            {
-                e.setLine(1, "Error");
-                e.setLine(2, "shop name is null");
-                e.getBlock().getState().update();
+            if (e.getLine(1).length() == 0) {
+                e.getBlock().breakNaturally();
+                e.getPlayer().sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Err. shop name is null" );
                 return;
             }
 
-            if (!ShopUtil.shopConfigFiles.containsKey(e.getLine(1)))
-            {
-                e.setLine(1, "Error");
-                e.setLine(2, "No shop");
-                e.setLine(3, "with that name");
-                e.getBlock().getState().update();
+            if (!ShopUtil.shopConfigFiles.containsKey(e.getLine(1))) {
+                e.getBlock().breakNaturally();
+                e.getPlayer().sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Err. No shop with that name." );
                 return;
             }
 
@@ -71,43 +69,48 @@ public class OnSignClick implements Listener
 
             Block tempBlock = e.getBlock();
             Block blockBehind = null;
-            if (tempBlock.getState() instanceof Sign)
-            {
+            if (tempBlock.getState() instanceof Sign) {
                 BlockData data = tempBlock.getBlockData();
-                if (data instanceof Directional)
-                {
+                if (data instanceof Directional) {
                     Directional directional = (Directional) data;
                     blockBehind = tempBlock.getRelative(directional.getFacing().getOppositeFace());
                 }
             }
-            if (blockBehind != null)
-            {
+            if (blockBehind != null) {
                 DynamicShop.ccSign.get().set(signId + ".attached", CreateID(blockBehind));
-            } else
-            {
-                e.setLine(1, "Error");
-                e.setLine(2, "Sign must be ");
-                e.setLine(3, "placed on wall");
-                e.getBlock().getState().update();
-                DynamicShop.console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + "Err. Sign must be placed on wall. " + signId);
+            } else {
+                e.getBlock().breakNaturally();
+                e.getPlayer().sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Err. Sign must be placed on wall." );
                 return;
             }
 
-            try
-            {
-                String shop = ChatColor.stripColor(e.getLine(1));
-                String mat = ChatColor.stripColor(e.getLine(2)).toUpperCase();
-                int i = ShopUtil.findItemFromShop(shop, new ItemStack(Material.getMaterial(mat)));
+            String shop = ChatColor.stripColor(e.getLine(1));
+            String signItemName = Objects.requireNonNull(e.getLine(2));
+            Material mat = ItemsUtil.GetMaterialFromShortname(signItemName);
 
-                e.setLine(2, ShopUtil.shopConfigFiles.get(shop).get().getString(i + ".mat"));
-
-                DynamicShop.ccSign.get().set(signId + ".mat", mat);
-            } catch (Exception exception)
-            {
-                e.setLine(2, "");
+            if(mat != null) {
+                int i = ShopUtil.findItemFromShop(shop, new ItemStack(mat));
+                if(i != -1) {
+                    e.setLine(2, signItemName);
+                    e.getBlock().getState().update();
+                    DynamicShop.ccSign.get().set(signId + ".mat", mat);
+                    DynamicShop.ccSign.save();
+                    e.getPlayer().sendMessage(DynamicShop.dsPrefix(e.getPlayer()) + t(e.getPlayer(), "MESSAGE.SIGN_SHOP_CREATED"));
+                } else {
+                    e.getBlock().breakNaturally();
+                    e.getPlayer().sendMessage(DynamicShop.dsPrefix(e.getPlayer()) + t(e.getPlayer(), "ERR.SIGN_ITEM_NOT_FOR_SALE"));
+                }
+            }  else if (signItemName.isEmpty()) {
+                    e.setLine(2, "");
+                    e.getBlock().getState().update();
+                    DynamicShop.ccSign.save();
+                    e.getPlayer().sendMessage(DynamicShop.dsPrefix(e.getPlayer()) + t(e.getPlayer(), "MESSAGE.SIGN_SHOP_CREATED"));
+            }
+            else {
+                e.getBlock().breakNaturally();
+                e.getPlayer().sendMessage(DynamicShop.dsPrefix(e.getPlayer()) + t(e.getPlayer(), "ERR.SIGN_ITEM_INVALID"));
             }
 
-            DynamicShop.ccSign.save();
         }
     }
 
@@ -140,7 +143,7 @@ public class OnSignClick implements Listener
                         try
                         {
                             String mat = ChatColor.stripColor(s.getLine(2)).toUpperCase();
-                            int i = ShopUtil.findItemFromShop(shop, new ItemStack(Material.getMaterial(mat)));
+                            int i = ShopUtil.findItemFromShop(shop, new ItemStack(getMaterial(mat)));
                             s.setLine(2, ShopUtil.shopConfigFiles.get(shop).get().getString(i + ".mat"));
                             DynamicShop.ccSign.get().set(signId + ".mat", mat);
                         } catch (Exception exception)
@@ -208,7 +211,7 @@ public class OnSignClick implements Listener
 
                     try
                     {
-                        int idx = ShopUtil.findItemFromShop(shopName, new ItemStack(Material.getMaterial(DynamicShop.ccSign.get().getString(signId + ".mat"))));
+                        int idx = ShopUtil.findItemFromShop(shopName, new ItemStack(getMaterial(DynamicShop.ccSign.get().getString(signId + ".mat"))));
 
                         if (idx != -1)
                         {

--- a/src/main/java/me/sat7/dynamicshop/utilities/ItemsUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/ItemsUtil.java
@@ -79,4 +79,21 @@ public final class ItemsUtil
                 replace("{info}", info)
         );
     }
+
+    /**
+     * Converts the item name to a material.
+     *
+     * @param shortname Short name of item.
+     * @return material item
+     */
+    public static Material GetMaterialFromShortname(String shortname) {
+        Material[] materials = Material.values();
+        for (Material material : materials) {
+            String materialShortname = StringUtil.getShortenedNameSign(material.name());
+            if(materialShortname.equals(shortname)) {
+                return material;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/me/sat7/dynamicshop/utilities/LangUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/LangUtil.java
@@ -333,6 +333,16 @@ public final class LangUtil
             ccLang.get().addDefault("ERR.FILE_CREATE_FAIL", "§e파일 생성에 실패했습니다.");
             ccLang.get().addDefault("ERR.INVALID_TRANSACTION", "이 거래는 더이상 유효하지 않습니다. 문제가 반복되면 서버 관리자에게 문의하세요.");
 
+            // Added in 3.7.0
+            ccLang.get().addDefault("ERR.SHOP_NULL", "§e상점 이름은 null일 수 없습니다.");
+            ccLang.get().addDefault("ERR.ITEMINFO_HAND_EMPTY", "아이템을 들고 있어야 합니다.");
+            ccLang.get().addDefault("HELP.ITEMINFO_USAGE", "§f그것에 대해 배우려면 손에 항목을 잡으십시오.");
+            ccLang.get().addDefault("HELP.ITEMINFO_REALNAME", "§7실제 이름: §3{item_realname}");
+            ccLang.get().addDefault("HELP.ITEMINFO_SIGN_NAME", "§7서명 이름: §3{item_signname}");
+            ccLang.get().addDefault("ERR.SIGN_ITEM_INVALID", "잘못된 항목입니다. /ds iteminfo 를 사용하여 표지판에 있는 항목의 이름을 찾으십시오.");
+            ccLang.get().addDefault("ERR.SIGN_ITEM_NOT_FOR_SALE", "먼저 상점에 항목을 추가한 다음 간판에 사용해야 합니다.");
+            ccLang.get().addDefault("MESSAGE.SIGN_SHOP_CREATED", "§a사인샵 생성!");
+
             ccLang.get().addDefault("ON", "켜짐");
             ccLang.get().addDefault("OFF", "꺼짐");
             ccLang.get().addDefault("SET", "설정");
@@ -653,6 +663,16 @@ public final class LangUtil
             ccLang.get().addDefault("ERR.CREATIVE", "§eYou cannot use this command in Creative mode. You do not have permission.");
             ccLang.get().addDefault("ERR.FILE_CREATE_FAIL", "§eFile creation failed");
             ccLang.get().addDefault("ERR.INVALID_TRANSACTION", "This transaction is no longer valid. If this problem recurs, contact your server administrator");
+
+            // Added in 3.7.0
+            ccLang.get().addDefault("ERR.SHOP_NULL", "§eShop name cannot be null.");
+            ccLang.get().addDefault("ERR.ITEMINFO_HAND_EMPTY", "You need to hold an item.");
+            ccLang.get().addDefault("HELP.ITEMINFO_USAGE", "§fHold an item in your hand to learn about it.");
+            ccLang.get().addDefault("HELP.ITEMINFO_REALNAME", "§7Real name: §3{item_realname}");
+            ccLang.get().addDefault("HELP.ITEMINFO_SIGN_NAME", "§7Sign name: §3{item_signname}");
+            ccLang.get().addDefault("ERR.SIGN_ITEM_INVALID", "Invalid item. Use /ds iteminfo to find the name of the item on the sign.");
+            ccLang.get().addDefault("ERR.SIGN_ITEM_NOT_FOR_SALE", "First you must add the item in the shop and then use it on the sign.");
+            ccLang.get().addDefault("MESSAGE.SIGN_SHOP_CREATED", "§aSign Shop created!");
 
             ccLang.get().addDefault("ON", "ON");
             ccLang.get().addDefault("OFF", "OFF");

--- a/src/main/java/me/sat7/dynamicshop/utilities/ShopUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/ShopUtil.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import me.sat7.dynamicshop.transactions.Calc;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -13,6 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import me.sat7.dynamicshop.DynamicShop;
 import me.sat7.dynamicshop.constants.Constants;
 import me.sat7.dynamicshop.files.CustomConfig;
+import com.google.common.base.CaseFormat;
 
 import static me.sat7.dynamicshop.utilities.LangUtil.t;
 
@@ -33,8 +35,7 @@ public final class ShopUtil
         SortShopDataAll();
     }
 
-    public static void ReloadAllShop()
-    {
+    public static void ReloadAllShop() {
         shopConfigFiles.clear();
 
         File[] listOfFiles = new File(DynamicShop.plugin.getDataFolder() + "/Shop").listFiles();
@@ -53,8 +54,7 @@ public final class ShopUtil
     }
 
     // 상점에서 빈 슬롯 찾기
-    public static int findEmptyShopSlot(String shopName, int startIdx, boolean addPage)
-    {
+    public static int findEmptyShopSlot(String shopName, int startIdx, boolean addPage) {
         CustomConfig data = shopConfigFiles.get(shopName);
         if(data == null)
             return -1;
@@ -82,8 +82,7 @@ public final class ShopUtil
     }
 
     // 상점에서 아이탬타입 찾기
-    public static int findItemFromShop(String shopName, ItemStack item)
-    {
+    public static int findItemFromShop(String shopName, ItemStack item) {
         if (item == null || item.getType().isAir())
             return -1;
 
@@ -122,12 +121,10 @@ public final class ShopUtil
     }
 
     // 상점에 아이탬 추가
-    public static boolean addItemToShop(String shopName, int idx, ItemStack item, double buyValue, double sellValue, double minValue, double maxValue, int median, int stock)
-    {
+    public static boolean addItemToShop(String shopName, int idx, ItemStack item, double buyValue, double sellValue, double minValue, double maxValue, int median, int stock) {
         return addItemToShop(shopName, idx, item, buyValue, sellValue, minValue, maxValue, median, stock, -1);
     }
-    public static boolean addItemToShop(String shopName, int idx, ItemStack item, double buyValue, double sellValue, double minValue, double maxValue, int median, int stock, int maxStock)
-    {
+    public static boolean addItemToShop(String shopName, int idx, ItemStack item, double buyValue, double sellValue, double minValue, double maxValue, int median, int stock, int maxStock) {
         CustomConfig data = shopConfigFiles.get(shopName);
         if (data == null)
             return false;
@@ -256,8 +253,7 @@ public final class ShopUtil
     }
 
     // 상점에서 아이탬 제거
-    public static void removeItemFromShop(String shopName, int idx)
-    {
+    public static void removeItemFromShop(String shopName, int idx) {
         CustomConfig data = shopConfigFiles.get(shopName);
         if (data == null)
             return;
@@ -267,8 +263,7 @@ public final class ShopUtil
     }
 
     // 상점 페이지 삽입
-    public static void insetShopPage(String shopName, int page)
-    {
+    public static void insetShopPage(String shopName, int page) {
         CustomConfig data = shopConfigFiles.get(shopName);
         if (data == null)
             return;
@@ -287,8 +282,7 @@ public final class ShopUtil
     }
 
     // 상점 페이지 삭제
-    public static void deleteShopPage(String shopName, int page)
-    {
+    public static void deleteShopPage(String shopName, int page) {
         CustomConfig data = shopConfigFiles.get(shopName);
         if (data == null)
             return;
@@ -962,4 +956,5 @@ public final class ShopUtil
             return true;
         }
     }
+
 }

--- a/src/main/java/me/sat7/dynamicshop/utilities/StringUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/StringUtil.java
@@ -1,0 +1,148 @@
+package me.sat7.dynamicshop.utilities;
+
+import org.bukkit.ChatColor;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+public final class StringUtil {
+
+    private StringUtil() {}
+
+    private static final String characters = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_'abcdefghijklmnopqrstuvwxyz{|}~¦ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜø£Ø×áíóúñÑªº¿®¬½¼¡«»";
+    private static final int[] extraWidth = {4,2,5,6,6,6,6,3,5,5,5,6,2,6,2,6,6,6,6,6,6,6,6,6,6,6,2,2,5,6,5,6,7,6,6,6,6,6,6,6,6,4,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,4,6,4,6,6,3,6,6,6,6,6,5,6,6,2,6,5,3,6,6,6,6,6,6,6,4,6,6,6,6,6,6,5,2,5,7,6,6,6,6,6,6,6,6,6,6,6,6,4,6,3,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,4,6,6,3,6,6,6,6,6,6,6,7,6,6,6,2,6,6,8,9,9,6,6,6,8,8,6,8,8,8,8,8,6,6,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,6,9,9,9,5,9,9,8,7,7,8,7,8,8,8,7,8,8,7,9,9,6,7,7,7,7,7,9,6,7,8,7,6,6,9,7,6,7,1};
+
+    /**
+     * Get the width that a character is displayed with in the default resource pack.
+     * This relies on a hardcoded character to width mapping and might not be precise in places.
+     * @param c The character to get the width of
+     * @return The width of the character (will return 10 for characters that we don't know the width of)
+     */
+    private static int getMinecraftCharWidth(char c) {
+        if (c != ChatColor.COLOR_CHAR) { //
+            int index = characters.indexOf(c);
+            if (index > -1) {
+                return extraWidth[index];
+            } else {
+                return 10;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Get the width that a string is displayed with in the default resource pack.
+     * This relies on a hardcoded character to width mapping and might not be precise in places.
+     * @param string The string to get the width of
+     * @return The width of the string
+     */
+    private static int getMinecraftStringWidth(String string) {
+        int width = 0;
+        for (char c : string.toCharArray()) {
+            width += getMinecraftCharWidth(c);
+        }
+        return width;
+    }
+
+    /**
+     * Capitalizes every first letter of a word
+     *
+     * @param string    String to reformat
+     * @param separator Word separator
+     * @return Reformatted string
+     */
+    private static String capitalizeFirstLetter(String string, char separator) {
+        if (string == null || string.isEmpty()) {
+            return string;
+        }
+
+        // Split into words
+        String[] words = string.toLowerCase(Locale.ROOT).split(String.valueOf(separator));
+        // Capitalize every word and return joined string
+        return Arrays.stream(words)
+                .map(word -> word.substring(0, 1).toUpperCase(Locale.ROOT) + word.substring(1))
+                .collect(Collectors.joining(" "));
+    }
+
+    /**
+     * Capitalizes every first letter of a word
+     *
+     * @param string String to reformat
+     * @return Reformatted string
+     * @see StringUtil#capitalizeFirstLetter(String, char)
+     */
+    private static String capitalizeFirstLetter(String string) {
+        return capitalizeFirstLetter(string, ' ');
+    }
+
+    /**
+     * Short the item name proportional to a sign.
+     *
+     * @param itemName name of item.
+     * @return the short-named item.
+     * @see StringUtil#getShortenedNameSign(String)
+     */
+    public static String getShortenedNameSign(String itemName) {
+        int maxWidth = 90; // Default value...
+        itemName = capitalizeFirstLetter(itemName.replace('_', ' '), ' ');
+        int width = getMinecraftStringWidth(itemName);
+        if (width <= maxWidth) {
+            return itemName;
+        }
+        String[] itemParts = itemName.split("[ \\-]");
+        itemName = String.join("", itemParts);
+        width = getMinecraftStringWidth(itemName);
+        if (width <= maxWidth) {
+            return itemName;
+        }
+        int exceeding = width - maxWidth;
+        int shortestIndex = 0;
+        int longestIndex = 0;
+        for (int i = 0; i < itemParts.length; i++) {
+            if (getMinecraftStringWidth(itemParts[longestIndex]) < getMinecraftStringWidth(itemParts[i])) {
+                longestIndex = i;
+            }
+            if (getMinecraftStringWidth(itemParts[shortestIndex]) > getMinecraftStringWidth(itemParts[i])) {
+                shortestIndex = i;
+            }
+        }
+        int shortestWidth = getMinecraftStringWidth(itemParts[shortestIndex]);
+        int longestWidth = getMinecraftStringWidth(itemParts[longestIndex]);
+        int remove = longestWidth - shortestWidth;
+        while (remove > 0 && exceeding > 0) {
+            int endWidth = getMinecraftCharWidth(itemParts[longestIndex].charAt(itemParts[longestIndex].length() - 1));
+            itemParts[longestIndex] = itemParts[longestIndex].substring(0, itemParts[longestIndex].length() - 1);
+            remove -= endWidth;
+            exceeding -= endWidth;
+        }
+
+        for (int i = itemParts.length - 1; i >= 0 && exceeding > 0; i--) {
+            int partWidth = getMinecraftStringWidth(itemParts[i]);
+
+            if (partWidth > shortestWidth) {
+                remove = partWidth - shortestWidth;
+            }
+
+            if (remove > exceeding) {
+                remove = exceeding;
+            }
+
+            while (remove > 0) {
+                int endWidth = getMinecraftCharWidth(itemParts[i].charAt(itemParts[i].length() - 1));
+                itemParts[i] = itemParts[i].substring(0, itemParts[i].length() - 1);
+                remove -= endWidth;
+                exceeding -= endWidth;
+            }
+        }
+
+        while (exceeding > 0) {
+            for (int i = itemParts.length - 1; i >= 0 && exceeding > 0; i--) {
+                int endWidth = getMinecraftCharWidth(itemParts[i].charAt(itemParts[i].length() - 1));
+                itemParts[i] = itemParts[i].substring(0, itemParts[i].length() - 1);
+                exceeding -= endWidth;
+            }
+        }
+        return String.join("", itemParts);
+    }
+}

--- a/src/main/java/me/sat7/dynamicshop/utilities/TabCompleteUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/TabCompleteUtil.java
@@ -81,6 +81,7 @@ public final class TabCompleteUtil
                     if (sender.hasPermission(P_ADMIN_SET_DEFAULT_SHOP)) temp.add("setdefaultshop");
                     if (sender.hasPermission(P_ADMIN_DELETE_OLD_USER)) temp.add("deleteOldUser");
                     if (sender.hasPermission(P_ADMIN_RELOAD)) temp.add("reload");
+                    if (sender.hasPermission(P_ADMIN_ITEM_INFO)) temp.add("iteminfo");
                     temp.add("cmdHelp");
 
                     AddToAutoCompleteIfValid(args[0]);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,14 +3,15 @@ version: ${project.version}
 main: me.sat7.dynamicshop.DynamicShop
 depend: [Vault]
 softdepend: [PlaceholderAPI, Jobs, LocaleLib]
-api-version: 1.13
-authors: [sat7]
+api-version: 1.18
+authors: [sat7, LincolnJota]
 description: Full GUI shop with dynamic prices
 commands:
   DynamicShop:
     description: "Full GUI shop with dynamic prices"
     aliases: [ds]
   shop:
+    description: "Open shop menu"
 permissions:
   dshop.use:
     description: Allows use of the /ds command

--- a/src/test/java/me/sat7/dynamicshop/files/FileUtil.java
+++ b/src/test/java/me/sat7/dynamicshop/files/FileUtil.java
@@ -8,6 +8,7 @@ public final class FileUtil {
     private FileUtil() {
 
     }
+    
 
     public static CustomConfig generateOutOfStockCustomConfig() {
         FileConfiguration config = new YamlConfiguration();


### PR DESCRIPTION
## Sign Update
- Some code bugs that crashed a server were fixed.

- Improved sign edit logic. (Before crashing the servers when placing a sign.)

- From now on the sign have a different item pattern: Many items got a gigantic name, impossible to put on the sign...

The sign didn't have a huge change, but the formatting of the items on the signs, see:
```
      [ds]
   SampleShop
     Diamond
```

### Okay, what about the item names that got long, eg Polished_blackstone_brick_stairs ?
The sign have a variable size limit of characters, and for that an algorithm was made that calculates the size of the sign and makes the name of the items shorter.

With the help of the command that was added, called "/ds iteminfo" I can get the real name and the name that will be on the sign, using the previous example, POLISHED_BLACKSTONE_BRICK_STAIRS will be PolisBlacBrickStai and this way with this algorithm it will be possible to add any named item giant, see:

```
       [ds]
    SampleShop
PolisBlacBrickStai
```


## New Command added

- the ```/ds iteminfo``` command was added.
- It is able to show you through the item you are holding, the name that will be on the sign, simple names will remain simple, compound and long names will be shortened to fit the sign.

- New permission added for this command: ```dshop.admin.iteminfo```

## Language
Didn't want to mess around for now, but it's unavoidable due to refactoring. Some texts were added in the translations due to necessity and are available for editing in their respective language files.

