### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/ds.yml
+++ b/.github/workflows/ds.yml
@@ -12,16 +12,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0 #https://github.com/actions/checkout/releases
     - run: sed "s/{BUILDID}/$GITHUB_RUN_NUMBER/g" pom.xml > _pom.xml; rm pom.xml; mv _pom.xml pom.xml
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3.9.0 #https://github.com/actions/setup-java/releases
       with:
-        java-version: 1.8
+        distribution: 'temurin'
+        java-version: 8
     - name: Build with Maven
       run: mvn clean install
     - run: mkdir staging && cp target/*.jar staging
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3.1.2 #https://github.com/actions/upload-artifact/releases
       with:
         name: Package
         path: staging

--- a/.github/workflows/ds.yml
+++ b/.github/workflows/ds.yml
@@ -2,7 +2,7 @@ name: DynamicShop
 
 on:
   push:
-    branches: [ master, update-actions ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/ds.yml
+++ b/.github/workflows/ds.yml
@@ -2,7 +2,7 @@ name: DynamicShop
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, update-actions ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Update Actions to get rid of deprecation warnings
Also added links to their release pages as a comment to easily find their latest version in the future
![image](https://user-images.githubusercontent.com/65610536/217935039-9f630cbc-c859-4d4c-b4f7-f59458e5b605.png)
Builds successfully without the warnings. [My Test Build](https://github.com/Chris6ix/DShop3/actions/runs/4138255939).